### PR TITLE
Fix Cloud Run startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ npm i
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev
+
+# For a production build (for example when deploying to Cloud Run) use:
+npm start
 ```
 
 **Edit a file directly in GitHub**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prestart": "npm run build",
+    "start": "vite preview --host 0.0.0.0 --port $PORT"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add `prestart` and `start` scripts so Node buildpack binds to `$PORT`
- document how to run the production build

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684445e594ec832faa59afa44ef3357d