### PR TITLE
Fix Cloud Run start by adding start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview --port $PORT --host"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add a `start` script so Google Cloud Run containers know how to boot

## Testing
- `npm run lint` *(fails: Fast refresh warnings and other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68444b3bddb8832fb8912fab9232ea5e